### PR TITLE
Change update-filelist.sh: 改为使用完整路径记录文件列表

### DIFF
--- a/vimfiles/tools/shell/bash/update-filelist.sh
+++ b/vimfiles/tools/shell/bash/update-filelist.sh
@@ -17,23 +17,23 @@ fi
 echo "  |- generate ${TMP}"
 
 if test "${FOLDERS}" != ""; then
-    find ${FORCE_POSIX_REGEX_1} . -type f -not -path "*/\.*" ${FORCE_POSIX_REGEX_2} ${IS_EXCLUDE} -regex ".*/("${FOLDERS}")/.*" ${FORCE_POSIX_REGEX_2} -regex ".*\.("${FILE_SUFFIXS}")$" > "${TMP}"
+    find ${FORCE_POSIX_REGEX_1} $PWD -type f -not -path "*/\.*" ${FORCE_POSIX_REGEX_2} ${IS_EXCLUDE} -regex ".*/("${FOLDERS}")/.*" ${FORCE_POSIX_REGEX_2} -regex ".*\.("${FILE_SUFFIXS}")$" > "${TMP}"
 
     if [[ "${FILE_SUFFIXS}" =~ __EMPTY__ ]]; then
-        find ${FORCE_POSIX_REGEX_1} . -type f -not -path "*/\.*" ${FORCE_POSIX_REGEX_2} ${IS_EXCLUDE} -regex ".*/("${FOLDERS}")/.*" ${FORCE_POSIX_REGEX_2}  |grep  -v  "\.\w*$" |xargs -i sh -c 'file="{}";type=$(file $file);[[ $type =~ "text" ]] && echo $file' >> "${TMP}"
+        find ${FORCE_POSIX_REGEX_1} $PWD -type f -not -path "*/\.*" ${FORCE_POSIX_REGEX_2} ${IS_EXCLUDE} -regex ".*/("${FOLDERS}")/.*" ${FORCE_POSIX_REGEX_2}  |grep  -v  "\.\w*$" |xargs -i sh -c 'file="{}";type=$(file $file);[[ $type =~ "text" ]] && echo $file' >> "${TMP}"
     fi
 
 else
-    find ${FORCE_POSIX_REGEX_1} . -type f -not -path "*/\.*" ${FORCE_POSIX_REGEX_2} -regex ".*\.("${FILE_SUFFIXS}")$" > "${TMP}"
+    find ${FORCE_POSIX_REGEX_1} $PWD -type f -not -path "*/\.*" ${FORCE_POSIX_REGEX_2} -regex ".*\.("${FILE_SUFFIXS}")$" > "${TMP}"
 
     if [[ "${FILE_SUFFIXS}" =~ __EMPTY__ ]]; then
-        find ${FORCE_POSIX_REGEX_1} . -type f -not -path "*/\.*" ${FORCE_POSIX_REGEX_2} -regex ".*\.("${FILE_SUFFIXS}")$" |grep  -v  "\.\w*$" |xargs -i sh -c 'file="{}";type=$(file $file);[[ $type =~ "text" ]] && echo $file' >> "${TMP}"
+        find ${FORCE_POSIX_REGEX_1} $PWD -type f -not -path "*/\.*" ${FORCE_POSIX_REGEX_2} -regex ".*\.("${FILE_SUFFIXS}")$" |grep  -v  "\.\w*$" |xargs -i sh -c 'file="{}";type=$(file $file);[[ $type =~ "text" ]] && echo $file' >> "${TMP}"
     fi
 
 fi
 
 # DISABLE
-# # find . -type f -not -path "*/\.*" > "${TMP}"
+# # find $PWD -type f -not -path "*/\.*" > "${TMP}"
 # if [ -f "${TMP}" ]; then
 #     echo "  |- filter by gawk ${TMP}"
 #     gawk -v file_filter=${FILE_FILTER_PATTERN} -v folder_filter=${FOLDER_FILTER_PATTERN} -f "${TOOLS}/gawk/file-filter-${GAWK_SUFFIX}.awk" "${TMP}">"${TMP2}"


### PR DESCRIPTION
**修复问题**
在当前工程中添加其他工程或库的tags（由Update命令生成），tag跳转使用了相对路径，而导致无法正确打开对应的文件。

**修改影响**
修改后，Update命令生成的files文件和tags文件会稍大一些；