### PR TITLE
adding support for custom ctags

### DIFF
--- a/vimfiles/tools/shell/bash/update-tags.sh
+++ b/vimfiles/tools/shell/bash/update-tags.sh
@@ -3,20 +3,25 @@
 # create tags
 echo "Creating Tags..."
 
-# choose ctags path first
-if [ -f "${DEST}/files" ]; then
-    FILES="-L ${DEST}/files"
+if [ ${CUSTOM} = true ]; then
+    echo "  |- move custom ctags to ${TARGET}"
+    cp "${SOURCE}" "${TARGET}"
 else
-    FILES="-R ."
-fi
+    # choose ctags path first
+    if [ -f "${DEST}/files" ]; then
+        FILES="-L ${DEST}/files"
+    else
+        FILES="-R ."
+    fi
 
-# process tags by langugage
-echo "  |- generate ${TMP}"
-${CTAGS_CMD} -o "${TMP}" ${OPTIONS} "${FILES}"
+    # process tags by langugage
+    echo "  |- generate ${TMP}"
+    ${CTAGS_CMD} -o "${TMP}" ${OPTIONS} "${FILES}"
 
-# replace old file
-if [ -f "${TMP}" ]; then
-    echo "  |- move ${TMP} to ${TARGET}"
-    mv -f "${TMP}" "${TARGET}"
+    # replace old file
+    if [ -f "${TMP}" ]; then
+        echo "  |- move ${TMP} to ${TARGET}"
+        mv -f "${TMP}" "${TARGET}"
+    fi
 fi
 echo "  |- done!"


### PR DESCRIPTION
I added a support for custom ctags. I work on LibreOffice and some of the ctags created with exuberant-ctags are too long for the tags plugin in exVim. LibreOffice does have a custom "make tags" command which creates a correct tags file. This config options allows users to use custom created tags files if they want to (pull request in the other projects added as well).