### PR TITLE
Add quotation mark to windows path

### DIFF
--- a/windows/replace-my-vim.bat
+++ b/windows/replace-my-vim.bat
@@ -3,12 +3,12 @@
 REM  Reference: http://www.wilsonmar.com/1envvars.htm
 set home=%USERPROFILE%
 
-copy /Y .\dist\ctags_lang %home%\.ctags
-copy /Y .vimrc %home%\.vimrc
-copy /Y .vimrc.plugins %home%\.vimrc.plugins
-copy /Y .vimrc.local %home%\.vimrc.local
-copy /Y .vimrc.plugins.local %home%\.vimrc.plugins.local
-rmdir /S /Q %home%\.vim
-xcopy /Y /E vimfiles %home%\.vim\
+copy /Y .\dist\ctags_lang "%home%\.ctags"
+copy /Y .vimrc "%home%\.vimrc"
+copy /Y .vimrc.plugins "%home%\.vimrc.plugins"
+copy /Y .vimrc.local "%home%\.vimrc.local"
+copy /Y .vimrc.plugins.local "%home%\.vimrc.plugins.local"
+rmdir /S /Q "%home%\.vim"
+xcopy /Y /E vimfiles "%home%\.vim\"
 
 @echo on


### PR DESCRIPTION
In case the user's name contains space, the command to
replace the vimrc will fail. Adding quotation mark will
fix this issue

Signed-off-by: Zhenfang Wei <kopkop@gmail.com>